### PR TITLE
inherit_from of rubocop_for_spec changed

### DIFF
--- a/rubocop_for_spec.yml
+++ b/rubocop_for_spec.yml
@@ -1,5 +1,5 @@
 inherit_from:
-  - https://raw.githubusercontent.com/pixta-dev/pixta-rubocop/master/rubocop.yml
+  - ../.rubocop.yml
 
 # Allow using `{...}` anytime
 Style/BlockDelimiters:


### PR DESCRIPTION
#1

.rubocop_for_specのinheritをRailsルートのrubocop.ymlを呼ぶようにしました。
