### PR TITLE
Prefer trailing comma in array and hash literals

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -60,3 +60,7 @@ Style/SignalException:
 # Allow empty condition in case statements
 Style/EmptyCaseCondition:
   Enabled: false
+
+# Prefer trailing comma in array and hash literals
+Style/TrailingCommaInLiteral:
+  EnforcedStyleForMultiline: comma


### PR DESCRIPTION
See #8 

Ref: http://rubocop.readthedocs.io/en/latest/cops_style/#styletrailingcommainliteral