### PR TITLE
Prefer `has_` as prefix of predicate methods

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -76,3 +76,13 @@ Style/PercentLiteralDelimiters:
     '%I': '()'
     '%w': '()'
     '%W': '()'
+
+# Allow `has_` as prefix of predicate methods
+Style/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
+
+# Prefer `has_?` style for Hash methods
+Style/PreferredHashMethods:
+  EnforcedStyle: verbose


### PR DESCRIPTION
Ruby's naming convention discourages developers from putting `has_` as a prefix to predicate methods.
For readability, however, I agree with the author of https://github.com/bbatsov/rubocop/issues/3428.

