### PR TITLE
replace `Style/PredicateName` to `Naming/PredicateName`

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -49,6 +49,12 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Max: 200
 
+# Allow `has_` as prefix of predicate methods
+Naming/PredicateName:
+  NamePrefixBlacklist:
+    - is_
+    - have_
+
 # Prefer double_quotes strings unless your string literal contains escape chars
 StringLiterals:
   EnforcedStyle: double_quotes
@@ -76,12 +82,6 @@ Style/PercentLiteralDelimiters:
     '%I': '()'
     '%w': '()'
     '%W': '()'
-
-# Allow `has_` as prefix of predicate methods
-Style/PredicateName:
-  NamePrefixBlacklist:
-    - is_
-    - have_
 
 # Prefer `has_?` style for Hash methods
 Style/PreferredHashMethods:


### PR DESCRIPTION
In version 0.51, the warning "Style / PredicateName has the wrong namespace - should be Naming" now appears. Fix it.