### PR TITLE
Use Style/TrailingCommaIn(Array|Hash)Literal

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -67,8 +67,12 @@ Style/EmptyCaseCondition:
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: comma
 
-# Prefer trailing comma in array and hash literals
-Style/TrailingCommaInLiteral:
+# Prefer trailing comma in array literals
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+
+# Prefer trailing comma in hash literals
+Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
 # Prefer parentheses for almost all percent literals


### PR DESCRIPTION
The cop doesn't work in RuboCop v0.53.0 because https://github.com/bbatsov/rubocop/pull/5307 split `Style/TrailingCommaInLiteral` into `Style/TrailingCommaInArrayLiteral` and `Style/TrailingCommaInHashLiteral`.
This PR copes with this change.