### PR TITLE
Replace 'NamePrefixBlacklist' with 'ForbiddenPrefixes'

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -47,7 +47,7 @@ Metrics/LineLength:
 
 # Allow `has_` as prefix of predicate methods
 Naming/PredicateName:
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
     - is_
     - have_
 


### PR DESCRIPTION
In rubocop version 0.77.0, the terms 'WhiteList' and 'BlackList' has been renamed to alternatives.
reference: https://github.com/rubocop-hq/rubocop/releases/tag/v0.77.0

This PR is to replace concerning terms with valid alternatives.

it's cornfirmed that rubocop 0.77.0 works when this PR is applied on pixta-lightbox on local environment.

###### before
```
root@ce5d0d0175b1:/var/www/pixta-lightbox# bundle exec rubocop app/models/folder.rb
/var/www/pixta-lightbox/.rubocop.yml: Warning: no department given for AsciiComments.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for SingleLineMethods.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Documentation.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MultilineBlockChain.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Lambda.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for ClassAndModuleChildren.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for FormatString.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MethodLength.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for StringLiterals.
Error: obsolete parameter NamePrefixBlacklist (for Naming/PredicateName) found in .rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml
`NamePrefixBlacklist` has been renamed to `ForbiddenPrefixes`.
```

###### after
```
root@ce5d0d0175b1:/var/www/pixta-lightbox# bundle exec rubocop app/models/folder.rb
/var/www/pixta-lightbox/.rubocop.yml: Warning: no department given for AsciiComments.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for SingleLineMethods.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for Documentation.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for MultilineBlockChain.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for Lambda.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for ClassAndModuleChildren.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for FormatString.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for MethodLength.
/var/www/pixta-lightbox/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml: Warning: no department given for StringLiterals.
Warning: unrecognized cop Rails found in .rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-replace-blacklist-rubocop-yml
Warning: unrecognized cop Rails found in .rubocop.yml
Inspecting 0 files
```
