### PR TITLE
Apply inherit_mode to Include and Exclude of AllCops

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Inherit `rubocop.yml` and add specific settings for each repository like `AllCop
 inherit_from:
   - https://raw.githubusercontent.com/pixta-dev/pixta-rubocop/master/rubocop.yml
 
+# Normally additional configs of AllCops/Include and AllCops/Ecxlude override to RuboCops's defaults.
+# But you'd like to apply both RuboCops's defaults and addtional configs of AllCops/Include and AllCops/Ecxlude.
+# ref: https://docs.rubocop.org/en/stable/configuration/#unusual-files-that-would-not-be-included-by-default
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+
 AllCops:
   TargetRubyVersion: TODO
   Include:

--- a/README.md
+++ b/README.md
@@ -33,7 +33,6 @@ inherit_mode:
 AllCops:
   TargetRubyVersion: TODO
   Include:
-    - '**/Rakefile'
     - '**/config.ru'
   Exclude:
     - 'Gemfile'
@@ -41,7 +40,6 @@ AllCops:
     - 'config/**/*'
     - 'db/**/*'
     - 'deploy/**/*'
-    - 'vendor/**/*'
 ```
 
 ### spec/.rubocop.yml

--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@ inherit_mode:
 
 AllCops:
   TargetRubyVersion: TODO
-  Include:
-    - '**/config.ru'
   Exclude:
     - 'Gemfile'
     - 'bin/*'

--- a/sample_rails_root/.rubocop.yml
+++ b/sample_rails_root/.rubocop.yml
@@ -8,8 +8,6 @@ inherit_mode:
 
 AllCops:
   TargetRubyVersion: TODO
-  Include:
-    - '**/config.ru'
   Exclude:
     - 'Gemfile'
     - 'bin/*'

--- a/sample_rails_root/.rubocop.yml
+++ b/sample_rails_root/.rubocop.yml
@@ -1,6 +1,11 @@
 inherit_from:
   - https://raw.githubusercontent.com/pixta-dev/pixta-rubocop/master/rubocop.yml
 
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+
 AllCops:
   TargetRubyVersion: TODO
   Include:

--- a/sample_rails_root/.rubocop.yml
+++ b/sample_rails_root/.rubocop.yml
@@ -9,7 +9,6 @@ inherit_mode:
 AllCops:
   TargetRubyVersion: TODO
   Include:
-    - '**/Rakefile'
     - '**/config.ru'
   Exclude:
     - 'Gemfile'
@@ -17,4 +16,3 @@ AllCops:
     - 'config/**/*'
     - 'db/**/*'
     - 'deploy/**/*'
-    - 'vendor/**/*'


### PR DESCRIPTION
Currently, the `rubocop` is working in pixta's repository with using configs and examples of `pixta-rubocop`. But it doesn't report problems when a code has problems.

Because from `rubocop` v0.56.0 it changed the behavior of `AllCops/Include` and `AllCops/Exclude` to the overriding way.
https://github.com/rubocop-hq/rubocop/blob/master/relnotes/v0.56.0.md#new-features

You can see this issue and pull request.
https://github.com/rubocop-hq/rubocop/issues/4247
https://github.com/rubocop-hq/rubocop/pull/5882

Oh my God... I will check that with using configs and examples of `pixta-rubocop` in a new rails v4.2.x project. I used this `.rubocop.yml`(Refer to README of `pixta-rubocop`).

```rb
inherit_from:
  - https://raw.githubusercontent.com/pixta-dev/pixta-rubocop/master/rubocop.yml

AllCops:
  TargetRubyVersion: 2.4
  Include:
    - '**/Rakefile'
    - '**/config.ru'
  Exclude:
    - 'Gemfile'
    - 'bin/*'
    - 'config/**/*'
    - 'db/**/*'
    - 'deploy/**/*'
    - 'vendor/**/*'
```

This one is the result. The target file is `Rakefile` and `config.ru` only. It can't use [default configs of `rubocop`](https://github.com/rubocop-hq/rubocop/blob/master/config/default.yml).

```yaml
vagrant@ubuntu-bionic ~/s/g/p/rails-with-docker-compose ❯❯❯ rubocop -v
0.77.0
vagrant@ubuntu-bionic ~/s/g/h/rails-with-docker-compose ❯❯❯ rubocop --list-target-files                                                                                                                                                                                    ✘ 1
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for SingleLineMethods.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Documentation.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MultilineBlockChain.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Lambda.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for ClassAndModuleChildren.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for FormatString.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MethodLength.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for StringLiterals.
Warning: unrecognized cop Rails found in .rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml
Warning: unrecognized cop Rails found in .rubocop.yml
Rakefile
config.ru
```

We should fix that problem. Normally `pixta-rubocop` uses default configs of `rubocop`. But we customized some configs to PIXTA. So we also want to apply that mind to `AllCops/Include` and `AllCops/Exclude`. If that we can use `inherit_mode`. `inherit_mode` has two options `merge` and `override`. 
https://docs.rubocop.org/en/stable/configuration/#merging-arrays-using-inherit_mode

In our case, we can specify `inherit_mode/merge` to `AllCops/Include` and `AllCops/Exclude`.

I also check that with using `inherit_mode/merge`. 

```yml
inherit_from:
  - https://raw.githubusercontent.com/pixta-dev/pixta-rubocop/master/rubocop.yml

inherit_mode:
  merge:
    - Include
    - Exclude

AllCops:
  TargetRubyVersion: 2.4
  Include:
    - '**/Rakefile'
    - '**/config.ru'
  Exclude:
    - 'Gemfile'
    - 'bin/*'
    - 'config/**/*'
    - 'db/**/*'
    - 'deploy/**/*'
    - 'vendor/**/*'

# Allow Japanese comments
AsciiComments:
  Enabled: false

```

This one is the result. it works well 💯 

```sh
vagrant@ubuntu-bionic ~/s/g/p/rails-with-docker-compose ❯❯❯ rubocop -v
0.77.0
vagrant@ubuntu-bionic ~/s/g/h/rails-with-docker-compose ❯❯❯ rubocop --list-target-files
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for SingleLineMethods.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Documentation.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MultilineBlockChain.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for Lambda.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for ClassAndModuleChildren.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for FormatString.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for MethodLength.
/home/vagrant/src/github.com-for-hamuyuuki/hamuyuuki/rails-with-docker-compose/.rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml: Warning: no department given for StringLiterals.
Warning: unrecognized cop Rails found in .rubocop-https---raw-githubusercontent-com-pixta-dev-pixta-rubocop-master-rubocop-yml
Warning: unrecognized cop Rails found in .rubocop.yml
Rakefile
app/controllers/application_controller.rb
app/helpers/application_helper.rb
config.ru
test/test_helper.rb
```

This PR changes README and examples in the `pixta-rubocop`. After this PR is LGTM, we need to apply that configs to pixta's repository.